### PR TITLE
Rebranding: Updated references to Thycotic with Delinea

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # The Delinea DevOps Secrets Vault SDK for Go
 
-![Tests](https://github.com/delinea/dsv-sdk-go/workflows/Tests/badge.svg)
+![Tests](https://github.com/thycotic/dsv-sdk-go/workflows/Tests/badge.svg)
 
 A Golang API and examples for [Delinea](https://delinea.com/)
-[DevOps Secrets Vault](https://delinea.com/products/devops-secrets-vault-password-management/).
+[DevOps Secrets Vault](https://delinea.com/products/devops-secrets-management-vault).
 
 ## Configure
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# The Thycotic DevOps Secrets Vault SDK for Go
+# The Delinea DevOps Secrets Vault SDK for Go
 
-![Tests](https://github.com/thycotic/dsv-sdk-go/workflows/Tests/badge.svg)
+![Tests](https://github.com/delinea/dsv-sdk-go/workflows/Tests/badge.svg)
 
-A Golang API and examples for [Thycotic](https://thycotic.com/)
-[DevOps Secrets Vault](https://thycotic.com/products/devops-secrets-vault-password-management/).
+A Golang API and examples for [Delinea](https://delinea.com/)
+[DevOps Secrets Vault](https://delinea.com/products/devops-secrets-vault-password-management/).
 
 ## Configure
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -42,7 +42,7 @@ type Configuration struct {
 	Tenant, TLD, URLTemplate string
 }
 
-// Vault provides access to secrets stored in Thycotic DSV
+// Vault provides access to secrets stored in Delinea DSV
 type Vault struct {
 	Configuration
 }


### PR DESCRIPTION
Updated references to Thycotic with Delinea in:
- Code comments
- Documentation

Not updated:
- Reference to Thycotic in `go.mod` and in `requires()`, as this will introduce breaking changes.